### PR TITLE
add full lookup

### DIFF
--- a/lmcache/v1/cache_controller/controller_manager.py
+++ b/lmcache/v1/cache_controller/controller_manager.py
@@ -39,6 +39,7 @@ from lmcache.v1.cache_controller.message import (  # isort: skip
     KVAdmitMsg,
     KVEvictMsg,
     LookupMsg,
+    FullLookupMsg,
     MoveMsg,
     Msg,
     MsgBase,
@@ -117,6 +118,8 @@ class LMCacheControllerManager:
     async def handle_orchestration_message(self, msg: OrchMsg) -> Optional[OrchRetMsg]:
         if isinstance(msg, LookupMsg):
             return await self.kv_controller.lookup(msg)
+        elif isinstance(msg, FullLookupMsg):
+            return await self.kv_controller.full_lookup(msg)
         elif isinstance(msg, HealthMsg):
             return await self.reg_controller.health(msg)
         elif isinstance(msg, QueryInstMsg):

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -178,21 +178,22 @@ class KVController:
     def full_lookup(self, msg: FullLookupMsg) -> FullLookupRetMsg:
         tokens = msg.tokens
         layout_info = {}
-        is_first = True # ensure the prefix cache is complete
+        last_end = -1
         for start, end, key in self.token_database.process_tokens(
             tokens, make_key=False
         ):
             assert isinstance(key, str)
-            if key not in self.kv_pool:
+            matched_pool = self.kv_pool.get(key, None)
+            if matched_pool is None:
                 break
-            for instance in self.kv_pool[key]:
+            for instance in matched_pool:
                 matched_instance = instance.instance_id
                 matched_location = instance.location
-                if is_first:
+                if last_end == -1:
                     layout_info[matched_instance] = [(matched_location, end)]
                 else:
-                    if matched_instance in layout_info:  # ensure continuous prefix
-                        layout_info[matched_instance].append((matched_location, end))
-            is_first = False
-        matched_info = list(layout_info.items())
-        return FullLookupRetMsg(matched_info=matched_info)
+                    cache_list = layout_info.get(matched_instance, None)
+                    if cache_list is not None and last_end == cache_list[-1][1]:
+                        cache_list.append((matched_location, end))
+            last_end = end
+        return FullLookupRetMsg(matched_info=list(layout_info.items()), chunk_size=self.token_database.chunk_size)

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -26,7 +26,9 @@ from lmcache.v1.cache_controller.message import (
     KVAdmitMsg,
     KVEvictMsg,
     LookupMsg,
+    FullLookupMsg,
     LookupRetMsg,
+    FullLookupRetMsg,
     MoveMsg,
     MoveRetMsg,
     PinMsg,
@@ -172,3 +174,23 @@ class KVController:
             matched_location = self.kv_pool[key][0].location
             layout_info[matched_instance] = (matched_location, end)
         return LookupRetMsg(layout_info=layout_info)
+    
+    async def full_lookup(self, msg: FullLookupMsg) -> FullLookupRetMsg:
+        tokens = msg.tokens
+        layout_infos = {}
+        for start, end, key in self.token_database.process_tokens(
+            tokens, make_key=False
+        ):
+            assert isinstance(key, str)
+            if key not in self.kv_pool:
+                break
+            for instance in self.kv_pool[key]:
+                matched_instance = instance.instance_id
+                matched_location = instance.location
+                layout_infos[matched_instance] = (matched_location, end)
+        matched_infos = sorted(
+            layout_infos.items(),
+            key=lambda x: (x[1][1]),  # Sort by end location
+            reverse=True,  # Reverse to get the longest prefix first
+        )
+        return FullLookupRetMsg(matched_infos=matched_infos)

--- a/lmcache/v1/cache_controller/controllers/kv_controller.py
+++ b/lmcache/v1/cache_controller/controllers/kv_controller.py
@@ -175,9 +175,10 @@ class KVController:
             layout_info[matched_instance] = (matched_location, end)
         return LookupRetMsg(layout_info=layout_info)
     
-    async def full_lookup(self, msg: FullLookupMsg) -> FullLookupRetMsg:
+    def full_lookup(self, msg: FullLookupMsg) -> FullLookupRetMsg:
         tokens = msg.tokens
-        layout_infos = {}
+        layout_info = {}
+        is_first = True # ensure the prefix cache is complete
         for start, end, key in self.token_database.process_tokens(
             tokens, make_key=False
         ):
@@ -187,10 +188,11 @@ class KVController:
             for instance in self.kv_pool[key]:
                 matched_instance = instance.instance_id
                 matched_location = instance.location
-                layout_infos[matched_instance] = (matched_location, end)
-        matched_infos = sorted(
-            layout_infos.items(),
-            key=lambda x: (x[1][1]),  # Sort by end location
-            reverse=True,  # Reverse to get the longest prefix first
-        )
-        return FullLookupRetMsg(matched_infos=matched_infos)
+                if is_first:
+                    layout_info[matched_instance] = [(matched_location, end)]
+                else:
+                    if matched_instance in layout_info:  # ensure continuous prefix
+                        layout_info[matched_instance].append((matched_location, end))
+            is_first = False
+        matched_info = list(layout_info.items())
+        return FullLookupRetMsg(matched_info=matched_info)

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -374,6 +374,8 @@ class FullLookupRetMsg(OrchRetMsg):
 
     # matched_info: list[Tuple[instance_id, list[Tuple[location, end]]]
     matched_info: list[Tuple[str, list[Tuple[str, int]]]]
+    chunk_size: int
+
     def describe(self) -> str:
         return f"The full layout info is {self.matched_info}"
 

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -259,6 +259,13 @@ class LookupMsg(OrchMsg):
     def describe(self) -> str:
         return f"Lookup tokens {self.tokens}"
 
+class FullLookupMsg(OrchMsg):
+    """Full lookup message"""
+
+    tokens: list[int]
+
+    def describe(self) -> str:
+        return f"Full lookup tokens {self.tokens}"
 
 class ClearMsg(OrchMsg):
     """Clear message"""
@@ -361,6 +368,14 @@ class LookupRetMsg(OrchRetMsg):
 
     def describe(self) -> str:
         return f"The layout info is {self.layout_info}"
+    
+class FullLookupRetMsg(OrchRetMsg):
+    """Full lookup return message"""
+
+    # matched_infos: list[Tuple[instance_id, Tuple[location, end]]]
+    matched_infos: list[Tuple[str, Tuple[str, int]]]
+    def describe(self) -> str:
+        return f"The full layout info is {self.matched_infos}"
 
 
 class ClearRetMsg(OrchRetMsg):

--- a/lmcache/v1/cache_controller/message.py
+++ b/lmcache/v1/cache_controller/message.py
@@ -372,10 +372,10 @@ class LookupRetMsg(OrchRetMsg):
 class FullLookupRetMsg(OrchRetMsg):
     """Full lookup return message"""
 
-    # matched_infos: list[Tuple[instance_id, Tuple[location, end]]]
-    matched_infos: list[Tuple[str, Tuple[str, int]]]
+    # matched_info: list[Tuple[instance_id, list[Tuple[location, end]]]
+    matched_info: list[Tuple[str, list[Tuple[str, int]]]]
     def describe(self) -> str:
-        return f"The full layout info is {self.matched_infos}"
+        return f"The full layout info is {self.matched_info}"
 
 
 class ClearRetMsg(OrchRetMsg):


### PR DESCRIPTION
[Feature] Support the lookup of the cached prefix info of every instance 

- Add a OrchMsg subclass FullLookupMsg and OrchRetMsg subclass FullLookupRetMsg
- Add a function KVController.full_lookup(msg: FullLookupMsg) -> FullLookupRetMsg that returns the cached prefix info of all instances, similar to KVController.lookup()
- Add FullLookupMsg handling in LMCacheControllerManager.handle_orchestration_message()