### PR TITLE
fix redis lookup

### DIFF
--- a/lmcache/v1/cache_engine.py
+++ b/lmcache/v1/cache_engine.py
@@ -244,9 +244,6 @@ class LMCacheEngine:
 
         tot_time = offload_time + put_time
 
-        if self.lookup_server is not None:
-            self.lookup_server.batched_insert(keys)
-
         logger.info(
             "Stored %d out of total %d tokens. size: %.4f gb, cost %.4f ms, "
             "throughput: %.4f GB/s; offload_time: %.4f ms, put_time: %.4f ms",
@@ -336,10 +333,6 @@ class LMCacheEngine:
             keys.append(keys_multi_layer)
             memory_objs.append(memory_objs_multi_layer)
             tot_token_num += num_tokens
-
-            # Update lookup server
-            if self.lookup_server is not None:
-                self.lookup_server.batched_insert(keys_multi_layer)
 
         if keys:
             # Transpose the keys and memory objects into layer major format

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -10,6 +10,7 @@ import torch
 # First Party
 from lmcache.utils import CacheEngineKey
 from lmcache.v1.memory_management import MemoryObj
+from lmcache.v1.storage_backend.storage_backend_listener import StorageBackendListener
 
 
 class StorageBackendInterface(metaclass=abc.ABCMeta):
@@ -31,6 +32,13 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
             raise
 
         self.dst_device = dst_device
+        self._listener: Optional[StorageBackendListener] = None
+
+    def set_listener(self, listener: StorageBackendListener):
+        """
+        Set the listener to receive events.
+        """
+        self._listener = listener
 
     @abc.abstractmethod
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:

--- a/lmcache/v1/storage_backend/abstract_backend.py
+++ b/lmcache/v1/storage_backend/abstract_backend.py
@@ -40,6 +40,13 @@ class StorageBackendInterface(metaclass=abc.ABCMeta):
         """
         self._listener = listener
 
+    def _on_evict(self, keys: List[CacheEngineKey]) -> None:
+        """
+        Evict keys from the storage backend.
+        """
+        if self._listener is not None:
+            self._listener.on_evict(self, keys)
+
     @abc.abstractmethod
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         """

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -64,19 +64,10 @@ class LocalCPUBackend(StorageBackendInterface):
         self.layerwise = config.use_layerwise
         self.enable_blending = config.enable_blending
 
-        # Callback functions for lookup server management
-        self.on_eviction_callback = None
 
     def __str__(self):
         return self.__class__.__name__
 
-    def set_callbacks(self, on_eviction=None):
-        """
-        Set callback function for lookup server management.
-        
-        :param on_eviction: Callback function called when keys are evicted
-        """
-        self.on_eviction_callback = on_eviction
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self.cpu_lock:
@@ -261,8 +252,7 @@ class LocalCPUBackend(StorageBackendInterface):
             # already freed above in order to allocate new memory object
             # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
-        if self.on_eviction_callback is not None:
-            self.on_eviction_callback(evict_keys, "LocalCPUBackend")
+        self._listener.on_evict(self, evict_keys)
         return memory_obj
 
     @_lmcache_nvtx_annotate
@@ -343,8 +333,7 @@ class LocalCPUBackend(StorageBackendInterface):
             # already freed above in order to allocate new memory objects
             # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
-        if self.on_eviction_callback is not None:
-            self.on_eviction_callback(evict_keys, "LocalCPUBackend")
+        self._listener.on_evict(self, evict_keys)
         return memory_objs
 
     def get_keys(self) -> List[CacheEngineKey]:
@@ -371,8 +360,7 @@ class LocalCPUBackend(StorageBackendInterface):
         for key in clear_keys:
             self.remove(key)
 
-        if self.on_eviction_callback is not None:
-            self.on_eviction_callback(clear_keys, "LocalCPUBackend")
+        self._listener.on_evict(self, clear_keys)
 
         return len(clear_keys)
 

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -64,8 +64,19 @@ class LocalCPUBackend(StorageBackendInterface):
         self.layerwise = config.use_layerwise
         self.enable_blending = config.enable_blending
 
+        # Callback functions for lookup server management
+        self.on_eviction_callback = None
+
     def __str__(self):
         return self.__class__.__name__
+
+    def set_callbacks(self, on_eviction=None):
+        """
+        Set callback function for lookup server management.
+        
+        :param on_eviction: Callback function called when keys are evicted
+        """
+        self.on_eviction_callback = on_eviction
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self.cpu_lock:
@@ -250,8 +261,8 @@ class LocalCPUBackend(StorageBackendInterface):
             # already freed above in order to allocate new memory object
             # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
-        if self.lookup_server is not None:
-            self.lookup_server.batched_remove(evict_keys)
+        if self.on_eviction_callback is not None:
+            self.on_eviction_callback(evict_keys, "LocalCPUBackend")
         return memory_obj
 
     @_lmcache_nvtx_annotate
@@ -332,8 +343,8 @@ class LocalCPUBackend(StorageBackendInterface):
             # already freed above in order to allocate new memory objects
             # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
-        if self.lookup_server is not None:
-            self.lookup_server.batched_remove(evict_keys)
+        if self.on_eviction_callback is not None:
+            self.on_eviction_callback(evict_keys, "LocalCPUBackend")
         return memory_objs
 
     def get_keys(self) -> List[CacheEngineKey]:
@@ -360,8 +371,8 @@ class LocalCPUBackend(StorageBackendInterface):
         for key in clear_keys:
             self.remove(key)
 
-        if self.lookup_server is not None:
-            self.lookup_server.batched_remove(clear_keys)
+        if self.on_eviction_callback is not None:
+            self.on_eviction_callback(clear_keys, "LocalCPUBackend")
 
         return len(clear_keys)
 

--- a/lmcache/v1/storage_backend/local_cpu_backend.py
+++ b/lmcache/v1/storage_backend/local_cpu_backend.py
@@ -252,7 +252,7 @@ class LocalCPUBackend(StorageBackendInterface):
             # already freed above in order to allocate new memory object
             # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
-        self._listener.on_evict(self, evict_keys)
+        super()._on_evict(evict_keys)
         return memory_obj
 
     @_lmcache_nvtx_annotate
@@ -333,7 +333,7 @@ class LocalCPUBackend(StorageBackendInterface):
             # already freed above in order to allocate new memory objects
             # this is to remove the key from the hot cache
             self.remove(evict_key, free_obj=False)
-        self._listener.on_evict(self, evict_keys)
+        super()._on_evict(evict_keys)
         return memory_objs
 
     def get_keys(self) -> List[CacheEngineKey]:
@@ -360,7 +360,7 @@ class LocalCPUBackend(StorageBackendInterface):
         for key in clear_keys:
             self.remove(key)
 
-        self._listener.on_evict(self, clear_keys)
+        super()._on_evict(clear_keys)
 
         return len(clear_keys)
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -193,19 +193,8 @@ class LocalDiskBackend(StorageBackendInterface):
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.usage = 0
 
-        # Callback function for lookup server management
-        self.on_eviction_callback = None
-
     def __str__(self):
         return "LocalDiskBackend"
-
-    def set_callbacks(self, on_eviction=None):
-        """
-        Set callback function for lookup server management.
-        
-        :param on_eviction: Callback function called when keys are evicted
-        """
-        self.on_eviction_callback = on_eviction
 
     def _key_to_path(
         self,
@@ -308,8 +297,7 @@ class LocalDiskBackend(StorageBackendInterface):
         # evict caches
         for evict_key in evict_keys:
             self.remove(evict_key)
-        if self.on_eviction_callback is not None:
-            self.on_eviction_callback(evict_keys, "LocalDiskBackend")
+        self._listener.on_evict(self, evict_keys)
 
         memory_obj.ref_count_up()
 
@@ -537,7 +525,6 @@ class LocalDiskBackend(StorageBackendInterface):
         return memory_obj
 
     def close(self) -> None:
-        if self.on_eviction_callback is not None:
-            self.disk_lock.acquire()
-            self.on_eviction_callback(list(self.dict.keys()), "LocalDiskBackend")
-            self.disk_lock.release()
+        self.disk_lock.acquire()
+        self._listener.on_evict(self, list(self.dict.keys()))
+        self.disk_lock.release()

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -193,8 +193,19 @@ class LocalDiskBackend(StorageBackendInterface):
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.usage = 0
 
+        # Callback function for lookup server management
+        self.on_eviction_callback = None
+
     def __str__(self):
         return "LocalDiskBackend"
+
+    def set_callbacks(self, on_eviction=None):
+        """
+        Set callback function for lookup server management.
+        
+        :param on_eviction: Callback function called when keys are evicted
+        """
+        self.on_eviction_callback = on_eviction
 
     def _key_to_path(
         self,
@@ -297,8 +308,8 @@ class LocalDiskBackend(StorageBackendInterface):
         # evict caches
         for evict_key in evict_keys:
             self.remove(evict_key)
-        if self.lookup_server is not None:
-            self.lookup_server.batched_remove(evict_keys)
+        if self.on_eviction_callback is not None:
+            self.on_eviction_callback(evict_keys, "LocalDiskBackend")
 
         memory_obj.ref_count_up()
 
@@ -404,8 +415,8 @@ class LocalDiskBackend(StorageBackendInterface):
         assert dtype is not None
         assert shape is not None
 
-        memory_obj = self.load_bytes_from_disk(path, dtype=dtype, shape=shape, fmt=fmt)
         self.disk_lock.release()
+        memory_obj = self.load_bytes_from_disk(path, dtype=dtype, shape=shape, fmt=fmt)
 
         return memory_obj
 
@@ -526,7 +537,7 @@ class LocalDiskBackend(StorageBackendInterface):
         return memory_obj
 
     def close(self) -> None:
-        if self.lookup_server is not None:
+        if self.on_eviction_callback is not None:
             self.disk_lock.acquire()
-            self.lookup_server.batched_remove(list(self.dict.keys()))
+            self.on_eviction_callback(list(self.dict.keys()), "LocalDiskBackend")
             self.disk_lock.release()

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -525,6 +525,6 @@ class LocalDiskBackend(StorageBackendInterface):
         return memory_obj
 
     def close(self) -> None:
-        self.disk_lock.acquire()
-        super()._on_evict(list(self.dict.keys()))
-        self.disk_lock.release()
+        with self.disk_lock:
+            keys = list(self.dict.keys())
+        super()._on_evict(keys)

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -297,7 +297,7 @@ class LocalDiskBackend(StorageBackendInterface):
         # evict caches
         for evict_key in evict_keys:
             self.remove(evict_key)
-        self._listener.on_evict(self, evict_keys)
+        super()._on_evict(evict_keys)
 
         memory_obj.ref_count_up()
 
@@ -526,5 +526,5 @@ class LocalDiskBackend(StorageBackendInterface):
 
     def close(self) -> None:
         self.disk_lock.acquire()
-        self._listener.on_evict(self, list(self.dict.keys()))
+        super()._on_evict(list(self.dict.keys()))
         self.disk_lock.release()

--- a/lmcache/v1/storage_backend/storage_backend_listener.py
+++ b/lmcache/v1/storage_backend/storage_backend_listener.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from typing import List, TYPE_CHECKING
+import abc
+
+from lmcache.utils import CacheEngineKey
+
+if TYPE_CHECKING:
+    from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
+
+
+class StorageBackendListener(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def _setup_backend_listener(self) -> None:
+        """
+        Set up listener for all backends.
+        """
+        raise NotImplementedError
+
+    def on_evict(self, backend: "StorageBackendInterface", keys: List[CacheEngineKey]):
+        pass

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -87,6 +87,21 @@ class StorageManager:
 
         self.nixl_offload_stream = torch.cuda.Stream()
 
+        # Set up callback functions for backends
+        if self.lookup_server is not None:
+            self._setup_backend_callbacks()
+
+    def _setup_backend_callbacks(self) -> None:
+        """
+        Set up callback functions for backends that need lookup server management.
+        This avoids direct dependencies between backends and storage_manager.
+        """
+        for backend_name, backend in self.storage_backends.items():
+            if hasattr(backend, 'set_callbacks'):
+                backend.set_callbacks(
+                    on_eviction=self._remove_from_lookup_server,
+                )
+
     @_lmcache_nvtx_annotate
     def allocate(
         self,
@@ -197,6 +212,9 @@ class StorageManager:
             # NOTE: the handling of exists_in_put_tasks
             # is done in the backend
             backend.batched_submit_put_task(keys, memory_objs)
+
+        if self.lookup_server is not None:
+            self.lookup_server.batched_insert(keys)
 
         for memory_obj in memory_objs:
             memory_obj.ref_count_down()
@@ -413,3 +431,22 @@ class StorageManager:
             self.thread.join()
 
         logger.info("Storage manager closed.")
+
+    def _remove_from_lookup_server(self, keys: Sequence[CacheEngineKey], from_backend: str) -> None:
+        """
+        remove keys from lookup server only if they exist.
+        """
+        if self.lookup_server is None:
+            return
+
+        search_range = ["LocalCPUBackend", "LocalDiskBackend"]
+        if from_backend in search_range:
+            search_range.remove(from_backend)
+        
+        keys_to_remove = []
+        for key in keys:
+            if not self.contains(key, search_range=search_range):
+                keys_to_remove.append(key)
+        
+        if keys_to_remove:
+            self.lookup_server.batched_remove(keys_to_remove)

--- a/lmcache/v1/storage_backend/storage_manager.py
+++ b/lmcache/v1/storage_backend/storage_manager.py
@@ -29,6 +29,7 @@ from lmcache.v1.memory_management import (
 from lmcache.v1.storage_backend import CreateStorageBackends
 from lmcache.v1.storage_backend.abstract_backend import StorageBackendInterface
 from lmcache.v1.storage_backend.local_cpu_backend import LocalCPUBackend
+from lmcache.v1.storage_backend.storage_backend_listener import StorageBackendListener
 
 if TYPE_CHECKING:
     # First Party
@@ -38,7 +39,7 @@ logger = init_logger(__name__)
 
 
 # TODO: extend this class to implement caching policies and eviction policies
-class StorageManager:
+class StorageManager(StorageBackendListener):
     """
     The StorageManager is responsible for managing the storage backends.
     """
@@ -87,20 +88,11 @@ class StorageManager:
 
         self.nixl_offload_stream = torch.cuda.Stream()
 
-        # Set up callback functions for backends
-        if self.lookup_server is not None:
-            self._setup_backend_callbacks()
+        self._setup_backend_listener()
 
-    def _setup_backend_callbacks(self) -> None:
-        """
-        Set up callback functions for backends that need lookup server management.
-        This avoids direct dependencies between backends and storage_manager.
-        """
+    def _setup_backend_listener(self) -> None:
         for backend_name, backend in self.storage_backends.items():
-            if hasattr(backend, 'set_callbacks'):
-                backend.set_callbacks(
-                    on_eviction=self._remove_from_lookup_server,
-                )
+            backend.set_listener(self)
 
     @_lmcache_nvtx_annotate
     def allocate(
@@ -432,16 +424,19 @@ class StorageManager:
 
         logger.info("Storage manager closed.")
 
-    def _remove_from_lookup_server(self, keys: Sequence[CacheEngineKey], from_backend: str) -> None:
+    def on_evict(self, backend: StorageBackendInterface, keys: List[CacheEngineKey]):
         """
-        remove keys from lookup server only if they exist.
+        remove keys from lookup server only if they don't exist in local backends.
+        
+        :param StorageBackendInterface backend: The backend that evicted the keys.
+        :param List[CacheEngineKey] keys: The keys that were evicted.
         """
         if self.lookup_server is None:
             return
 
         search_range = ["LocalCPUBackend", "LocalDiskBackend"]
-        if from_backend in search_range:
-            search_range.remove(from_backend)
+        if str(backend) in search_range:
+            search_range.remove(str(backend))
         
         keys_to_remove = []
         for key in keys:


### PR DESCRIPTION
Fix P2P sharing: cannot retrieve from other instances' disk
use callback function to  move all lookup server insert and remove operations to storage_manager

[in local_disk_backend.py]:
Since load_bytes_from_disk() does not use self.dict, I move self.disk_lock.release() before load_bytes_from_disk(), otherwise it may cause deadlock

**Results**
run the example from https://github.com/LMCache/LMCache/issues/1189

```
[2025-08-01 07:31:00,886] LMCache INFO: Reqid: 0, Total tokens 5000, LMCache hit tokens: 5000, need to load: 4999 (vllm_v1_adapter.py:800:lmcache.integration.vllm.vllm_v1_adapter)
Adding requests: 100%|███████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 43.08it/s]
Processed prompts:   0%|                                     | 0/2 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][2025-08-01 07:31:00,894] LMCache INFO: Post-initializing LMCacheEngine (cache_engine.py:147:lmcache.v1.cache_engine)
[2025-08-01 07:31:00,896] LMCache INFO: Connected by ('127.0.0.1', 58500) (naive_server.py:365:lmcache.v1.distributed_server.naive_server)
[2025-08-01 07:31:00,942] LMCache INFO: Time to get data: 0.00024171499535441399 from cpu_cache, time to send meta: 0.00018604611977934837, time to send data: 0.045373911038041115 (naive_server.py:410:lmcache.v1.distributed_server.naive_server)
.......
[2025-08-01 07:31:01,305] LMCache INFO: Retrieved 5000 out of 5000 out of total 5000 tokens (cache_engine.py:492:lmcache.v1.cache_engine)
[2025-08-01 07:31:01,359] LMCache INFO: Reqid: 1, Total tokens 6000, LMCache hit tokens: 6000, need to load: 5999 (vllm_v1_adapter.py:800:lmcache.integration.vllm.vllm_v1_adapter)
[2025-08-01 07:31:01,365] LMCache INFO: Connected by ('127.0.0.1', 58686) (naive_server.py:365:lmcache.v1.distributed_server.naive_server)
[2025-08-01 07:31:01,366] LMCache WARNING: Cannot use O_DIRECT for this file, size is not aligned to disk block size. (local_disk_backend.py:515:lmcache.v1.storage_backend.local_disk_backend)
[2025-08-01 07:31:01,385] LMCache INFO: Time to get data: 0.00872130086645484 from disk_storage, time to send meta: 0.00010993191972374916, time to send data: 0.009845050051808357 
......
[2025-08-01 07:31:01,795] LMCache INFO: Time to get data: 0.003065057098865509 from disk_storage, time to send meta: 6.710691377520561e-05, time to send data: 0.0051400670781731606 (naive_server.py:410:lmcache.v1.distributed_server.naive_server)
[2025-08-01 07:31:01,825] LMCache INFO: Retrieved 6000 out of 6000 out of total 6000 tokens (cache_engine.py:492:lmcache.v1.cache_engine)
Processed prompts:  50%|█████████████             | 1/2 [00:01<00:01,  1.14s/it, est. speed input: 4400.20 toks/s, output: 8.80 toks/s][2025-08-01 07:31:02,043] LMCache WARNING: In connector.start_load_kv, but the attn_metadata is None (vllm_v1_adapter.py:443:lmcache.integration.vllm.vllm_v1_adapter)
Processed prompts: 100%|█████████████████████████| 2/2 [00:01<00:00,  1.73it/s, est. speed input: 9521.52 toks/s, output: 17.31 toks/s]
Generated text: "Nice to meet you. What's your name?"
Generated text: 'Hello, how are you?Hello, how are'
KV cache retrieve completed in 1.207 seconds
```
I add some log INFOs, and it shows that now we can successfully retrieve cache from other nodes' cpu or disk